### PR TITLE
Better repr and debugging for Q expressions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,3 +39,12 @@ Null Wrappers
 
 .. autoclass:: NullCollection
    :members:
+
+
+Expressions
+===========
+
+.. autoclass:: Expression
+   :members:
+
+.. autoclass:: QDebug

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -65,7 +65,8 @@ identical:
 
 Notice that in these examples, the only difference is that
 you always call ``val()`` to pull data out of a Soupy wrapper
-when you are ready.
+when you are ready. **This is the essential concept to learn
+when transitioning from BeautifulSoup to Soupy**.
 
 Things get more interesting when we look at corner cases (and
 the web is *full* of corner cases). For example,

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -157,11 +157,12 @@ search.
 Functional API
 --------------
 
-The main benefit of Soupy's wrappers is the ability to reliably chain
-them together. This also allows you to use general purpose libraries
-like itertools, functools, toolz, more_itertools, etc., to compose
-more complex data processing pipelines. For convenience, Soupy also priovides
-several such utilities to support more extensive method chaining.
+The main benefit of Soupy's wrappers is the ability to reliably chain them
+together. This also allows you to use general purpose libraries like itertools,
+functools, `toolz <http://toolz.readthedocs.org/en/latest/>`_,  `more_itertools
+<https://pythonhosted.org/more-itertools/index.html>`_,  etc., to compose more
+complex data processing pipelines. For convenience, Soupy also priovides several
+such utilities to support more extensive method chaining.
 
 
 Iterating over results with each, dump, dictzip
@@ -169,7 +170,7 @@ Iterating over results with each, dump, dictzip
 
 A common pattern in BeautifulSoup is to iterate over results from a
 call like :meth:`~Node.find_all` using a list comprehension. For example,
-consider the query to extract all the movie Titles on `this IMDB page <http://chrisbeaumont.github.io/soupy/imdb_demo.html>`_
+consider the query to extract all the movie titles on `this IMDB page <http://chrisbeaumont.github.io/soupy/imdb_demo.html>`_
 
 
 .. testcode:: imdb
@@ -381,4 +382,93 @@ the result isn't Truthy.
   ...
   NullValueError: Too small!
 
+
+Working with Q Expressions
+--------------------------
+
+Many of the previous examples have used the `Q` function-builder as a
+shorthand for ``lambda`` or manually defined functions. As mentioned
+above, ``Q[stuff]`` is rougly equivalent to ``lambda x: x[stuff]``,
+so it should feel natural to pick up. Here are some example Q expressions,
+and their lambda equivalents:
+
+
+   ================== ====================================
+   Q Expression       lambda expression
+   ================== ====================================
+   ``Q + 3``          ``lambda x: x + 3``
+   ``Q.a``            ``lambda x: x.a``
+   ``Q(5)``           ``lambda x: x(5)``
+   ``Q.func(3)``      ``lambda x: x.func(3)``
+   ``Q[key]``         ``lambda x: x['key']``
+   ``Q.map(Q > 3)``   ``lambda x: x.map(lambda y: y > 3)``
+   ================== ====================================
+
+The third example introduces a slight twist with Q expressions. Because
+``Q(5)`` builds a function like ``lambda x: x(5)``, we can't directly
+call this function using the normal ``(arg)`` syntax -- doing so would
+actually build a *new* function behaving like ``lambda x: x(5)(arg)``.
+You normally don't need to manually evaulate Q expressions, but if you
+do you can use the :meth:`~Expression.__eval__` method.
+
+.. doctest::
+
+  >>> x = Q.upper()[0:2]
+  >>> x('testing')  # No! Builds a new function
+  Q.upper()[slice(0, 2, None)]('testing')
+  >>> x.__eval__('testing')  # Yes!
+  'TE'
+
+Debugging Q expressions
+........................
+
+Despite your best efforts, you will *still* encounter messy documents
+that trigger errors in your code. Here's a simplified example:
+
+.. doctest:: qdebug
+
+  >>> html = ['<a href="/index"></a>'] * 100
+  >>> html[30] = '<a></a>'
+  >>> dom = Soupy(''.join(html))
+  >>> dom.find_all('a').each(Q['href'].upper())
+  Traceback (most recent call last):
+  ...
+  KeyError: 'href'
+
+      Encountered when evaluating Node(<a></a>)['href']
+
+This code tries to extract the links in all ``a`` tags, but fails
+on links that don't define the ``href`` attribute. Debugging issues
+like this can be frustrating, because these errors are often triggered
+by rare edge cases in the document that can be hard to track down.
+
+If your errors are generated inside a Q expression (as is the case here),
+the :meth:`Q.debug_ <Expression.debug_>` method will return data to isolate
+the failure.
+
+.. doctest:: qdebug
+
+  >>> dbg = Q.debug_()
+  >>> dbg
+  QDebug(full_expr=Q['href'].upper(), expr=['href'], val=Node(<a></a>))
+  >>> dbg.full_expr
+  Q['href'].upper()
+  >>> dbg.expr
+  ['href']
+  >>> dbg.val
+  Node(<a></a>)
+
+The three attributes returned by ``debug_`` are the full Q expression
+that triggered the error, the specific subexpression that triggered
+the error (in this case, the ``['href']`` part), and the value passed
+to the Q expression. So for example we can re-trigger the error via
+
+.. doctest:: qdebug
+
+  >>> dbg.expr.__eval__(dbg.val)
+  Traceback (most recent call last):
+  ...
+  KeyError: 'href'
+
+      Encountered when evaluating Node(<a></a>)['href']
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -409,14 +409,14 @@ The third example introduces a slight twist with Q expressions. Because
 call this function using the normal ``(arg)`` syntax -- doing so would
 actually build a *new* function behaving like ``lambda x: x(5)(arg)``.
 You normally don't need to manually evaulate Q expressions, but if you
-do you can use the :meth:`~Expression.__eval__` method.
+do you can use the :meth:`~Expression.eval_` method.
 
 .. doctest::
 
   >>> x = Q.upper()[0:2]
   >>> x('testing')  # No! Builds a new function
   Q.upper()[slice(0, 2, None)]('testing')
-  >>> x.__eval__('testing')  # Yes!
+  >>> x.eval_('testing')  # Yes!
   'TE'
 
 Debugging Q expressions
@@ -468,7 +468,7 @@ So for example we can re-trigger the error via
 
 .. doctest:: qdebug
 
-  >>> dbg.expr.__eval__(dbg.val)
+  >>> dbg.expr.eval_(dbg.val)
   Traceback (most recent call last):
   ...
   IndexError: list index out of range

--- a/soupy.py
+++ b/soupy.py
@@ -1238,7 +1238,7 @@ class Expression(object):
         yield self
 
     def _chain(self, other):
-        return Chain(tuple(self) + tuple(other))
+        return Chain(tuple(iter(self)) + tuple(iter(other)))
 
     def __getattr__(self, key):
         return self._chain(Attr(key))

--- a/soupy.py
+++ b/soupy.py
@@ -1187,7 +1187,7 @@ def either(*funcs):
 
 def _helpful_failure(method):
     """
-    Decorator for __eval__ that prints a helpful error message
+    Decorator for eval_ that prints a helpful error message
     if an exception is generated in a Q expression
     """
 
@@ -1297,7 +1297,7 @@ class Expression(object):
         return BinaryOp(operator.mod, '%', self, other)
 
     @_helpful_failure
-    def __eval__(self, val):
+    def eval_(self, val):
         """
         Pass the argument ``val`` to the function, and return the result.
 
@@ -1352,7 +1352,7 @@ class Call(Expression):
         self._kwargs = kwargs
 
     @_helpful_failure
-    def __eval__(self, val):
+    def eval_(self, val):
         return val.__call__(*self._args, **self._kwargs)
 
     def __str__(self):
@@ -1372,14 +1372,14 @@ class BinaryOp(Expression):
         self.symbol = symbol
 
     @_helpful_failure
-    def __eval__(self, val):
+    def eval_(self, val):
         left = self.left
         right = self.right
         if isinstance(left, Expression):
-            left = left.__eval__(val)
+            left = left.eval_(val)
 
         if isinstance(right, Expression):
-            right = right.__eval__(val)
+            right = right.eval_(val)
 
         return self.op(left, right)
 
@@ -1400,7 +1400,7 @@ class Attr(Expression):
         self._name = attribute_name
 
     @_helpful_failure
-    def __eval__(self, val):
+    def eval_(self, val):
         return operator.attrgetter(self._name)(val)
 
     def __str__(self):
@@ -1414,7 +1414,7 @@ class GetItem(Expression):
         self._name = key
 
     @_helpful_failure
-    def __eval__(self, val):
+    def eval_(self, val):
         return operator.itemgetter(self._name)(val)
 
     def __str__(self):
@@ -1432,9 +1432,9 @@ class Chain(Expression):
             yield item
 
     @_helpful_failure
-    def __eval__(self, val):
+    def eval_(self, val):
         for item in self._items:
-            val = item.__eval__(val)
+            val = item.eval_(val)
         return val
 
     def __str__(self):
@@ -1442,9 +1442,9 @@ class Chain(Expression):
 
 
 def _make_callable(func):
-    # If func is an expression, we call via __eval__
+    # If func is an expression, we call via eval_
     # otherwise, we call func directly
-    return getattr(func, '__eval__', func)
+    return getattr(func, 'eval_', func)
 
 
 def _unwrap(val):

--- a/soupy.py
+++ b/soupy.py
@@ -1,18 +1,27 @@
 from __future__ import print_function, division, unicode_literals
 
 from abc import ABCMeta, abstractproperty, abstractmethod
+from collections import namedtuple
 from itertools import takewhile, dropwhile
 import operator
+import re
+import sys
 
 from bs4 import BeautifulSoup, PageElement, NavigableString
 import six
-from six.moves import map as imap
+from six.moves import map
 
 
 __all__ = ['Soupy', 'Q', 'Node', 'Scalar', 'Collection',
            'Null', 'NullNode', 'NullCollection',
-           'either', 'NullValueError']
+           'either', 'NullValueError', 'QDebug']
 
+
+# extract the thing inside string reprs (eg u'abc' -> abc)
+QUOTED_STR = re.compile("^[ub]?['\"](.*?)['\"]$")
+
+QDebug = namedtuple('QDebug', ('full_expr', 'expr', 'val'))
+"""Namedtuple that holds information about a failed expression evaluation."""
 
 @six.add_metaclass(ABCMeta)
 class Wrapper(object):
@@ -250,12 +259,7 @@ class Some(Wrapper):
     def __str__(self):
         # returns unicode
         # six builds appropriate py2/3 methods from this
-        value = repr(self._value)
-
-        if isinstance(value, six.binary_type):
-            value = value.decode('utf-8')
-
-        return "%s(%s)" % (type(self).__name__, value)
+        return "%s(%s)" % (type(self).__name__, _repr(self._value))
 
     def __repr__(self):
         return repr(self.__str__())[1:-1]  # trim off quotes
@@ -466,7 +470,7 @@ class Collection(Some):
         Returns a new Collection.
         """
         func = _make_callable(func)
-        return Collection(imap(func, self._items))
+        return Collection(map(func, self._items))
 
     def filter(self, func):
         """
@@ -767,7 +771,7 @@ class Node(NodeLike, Some):
 
     def _wrap_multi(self, func):
         vals = func(self._value)
-        return Collection(imap(Node, vals))
+        return Collection(map(Node, vals))
 
     def _wrap_scalar(self, func):
         val = func(self._value)
@@ -1168,20 +1172,52 @@ def either(*funcs):
     return either
 
 
+def _helpful_failure(method):
+    """
+    Decorator for __eval__ that prints a helpful error message
+    if an exception is generated in a Q expression
+    """
+    def wrapper(self, val):
+        try:
+            return method(self, val)
+        except:
+            exc_cls, inst, tb = sys.exc_info()
+
+            if hasattr(inst, '_RERAISE'):
+                Q.__debug_info__ = QDebug(self, *Q.__debug_info__[1:])
+                raise
+
+            # Show val, unless it's too long
+            prettyval = repr(val)
+            if len(prettyval) > 150:
+                prettyval = "<%s instance>" % (type(val).__name__)
+
+            msg = "{0}\n\n\tEncountered when evaluating {1}{2}".format(
+                inst, prettyval, self)
+
+            new_exc = exc_cls(msg)
+            new_exc._RERAISE = True
+            Q.__debug_info__ = QDebug(self, self, val)
+
+            six.reraise(exc_cls, new_exc, tb)
+
+    return wrapper
+
+
+@six.python_2_unicode_compatible
 class Expression(object):
 
-    def _chain(self, other):
-        ops = []
-        if isinstance(self, Chain):
-            ops = self._items
-        else:
-            ops = [self]
-        if isinstance(other, Chain):
-            ops.extend(other._items)
-        else:
-            ops.append(other)
+    def __str__(self):
+        return 'Q'
 
-        return Chain(ops)
+    def __repr__(self):
+        return repr(str(self))[1:-1]  # trim quotes
+
+    def __iter__(self):
+        yield self
+
+    def _chain(self, other):
+        return Chain(tuple(self) + tuple(other))
 
     def __getattr__(self, key):
         return self._chain(Attr(key))
@@ -1193,68 +1229,117 @@ class Expression(object):
         return self._chain(Call(args, kwargs))
 
     def __gt__(self, other):
-        return BinaryOp(operator.gt, self, other)
+        return BinaryOp(operator.gt, '>', self, other)
 
     def __ge__(self, other):
-        return BinaryOp(operator.ge, self, other)
+        return BinaryOp(operator.ge, '>=', self, other)
 
     def __lt__(self, other):
-        return BinaryOp(operator.lt, self, other)
+        return BinaryOp(operator.lt, '<', self, other)
 
     def __le__(self, other):
-        return BinaryOp(operator.le, self, other)
+        return BinaryOp(operator.le, '<=', self, other)
 
     def __eq__(self, other):
-        return BinaryOp(operator.eq, self, other)
+        return BinaryOp(operator.eq, '==', self, other)
 
     def __ne__(self, other):
-        return BinaryOp(operator.ne, self, other)
+        return BinaryOp(operator.ne, '!=', self, other)
 
     def __add__(self, other):
-        return BinaryOp(operator.add, self, other)
+        return BinaryOp(operator.add, '+', self, other)
 
     def __sub__(self, other):
-        return BinaryOp(operator.sub, self, other)
+        return BinaryOp(operator.sub, '-', self, other)
 
     def __div__(self, other):
-        return BinaryOp(operator.__div__, self, other)
+        return BinaryOp(operator.__div__, '/', self, other)
 
     def __floordiv__(self, other):
-        return BinaryOp(operator.floordiv, self, other)
+        return BinaryOp(operator.floordiv, '//', self, other)
 
     def __truediv__(self, other):
-        return BinaryOp(operator.truediv, self, other)
+        return BinaryOp(operator.truediv, '/', self, other)
 
     def __mul__(self, other):
-        return BinaryOp(operator.mul, self, other)
+        return BinaryOp(operator.mul, '*', self, other)
+
+    def __rmul__(self, other):
+        return BinaryOp(operator.mul, '*', other, self)
 
     def __pow__(self, other):
-        return BinaryOp(operator.pow, self, other)
+        return BinaryOp(operator.pow, '**', self, other)
 
     def __mod__(self, other):
-        return BinaryOp(operator.mod, self, other)
+        return BinaryOp(operator.mod, '%', self, other)
 
+    @_helpful_failure
     def __eval__(self, val):
         return val
 
+    def debug_(self):
+        """
+        Returns debugging information for the previous error raised
+        during expression evaluation.
 
+        Returns a QDebug namedtuple with three fields:
+
+          - full_expr is the last full expression to have raised an exception
+          - expr is the specific sub-expression that raised the exception
+          - val is the value that expr tried to evaluate.
+
+        If no exceptions have been triggered from expresison evaluation,
+        then each field is None.
+
+        Examples:
+
+            >>> Scalar('test').map(Q.upper().foo)
+            Traceback (most recent call last):
+            ...
+            AttributeError: 'str' object has no attribute 'foo'
+            ...
+            >>> dbg = Q.debug_()
+            >>> dbg.full_expr
+            Q.upper().foo
+            >>> dbg.expr
+            .foo
+            >>> dbg.val
+            'TEST'
+        """
+        result = self.__debug_info__
+        if isinstance(result, QDebug):
+            return result
+        return QDebug(None, None, None)
+
+
+@six.python_2_unicode_compatible
 class Call(Expression):
-
+    """An expression for calling a function or method"""
     def __init__(self, args, kwargs):
         self._args = args
         self._kwargs = kwargs
 
+    @_helpful_failure
     def __eval__(self, val):
         return val.__call__(*self._args, **self._kwargs)
 
+    def __str__(self):
+        result = list(map(_uniquote, self._args))
+        if self._kwargs:
+            result.append('**%s' % _uniquote(self._kwargs))
+        return '(%s)' % (', '.join(result))
 
+
+@six.python_2_unicode_compatible
 class BinaryOp(Expression):
-
-    def __init__(self, op, left, right):
+    """A binary operation"""
+    def __init__(self, op, symbol, left, right):
         self.op = op
         self.left = left
         self.right = right
+        self.symbol = symbol
 
+    @_helpful_failure
     def __eval__(self, val):
         left = self.left
         right = self.right
@@ -1266,34 +1351,62 @@ class BinaryOp(Expression):
 
         return self.op(left, right)
 
+    def __str__(self):
+        l, r = self.left, self.right
+        if isinstance(l, BinaryOp):
+            l = '(%s)' % str(l)
+        if isinstance(r, BinaryOp):
+            r = '(%s)' % str(r)
 
+        return "%s %s %s" % (l, self.symbol, r)
+
+
+@six.python_2_unicode_compatible
 class Attr(Expression):
-
+    """An expression for fetching an attribute (eg, obj.item)"""
     def __init__(self, attribute_name):
         self._name = attribute_name
 
+    @_helpful_failure
     def __eval__(self, val):
         return operator.attrgetter(self._name)(val)
 
+    def __str__(self):
+        return '.%s' % self._name
 
+
+@six.python_2_unicode_compatible
 class GetItem(Expression):
-
+    """An expression for getting an item (eg, obj['item'])"""
     def __init__(self, key):
         self._name = key
 
+    @_helpful_failure
     def __eval__(self, val):
         return operator.itemgetter(self._name)(val)
 
+    def __str__(self):
+        return "[%s]" % _uniquote(self._name)
 
+
+@six.python_2_unicode_compatible
 class Chain(Expression):
-
+    """An chain of expressions (eg a.b.c)"""
     def __init__(self, items):
         self._items = items
 
+    def __iter__(self):
+        for item in self._items:
+            yield item
+
+    @_helpful_failure
     def __eval__(self, val):
         for item in self._items:
             val = item.__eval__(val)
         return val
+
+    def __str__(self):
+        return ''.join(map(_uniquote, self._items))
 
 
 def _make_callable(func):
@@ -1306,6 +1419,37 @@ def _unwrap(val):
     if isinstance(val, Wrapper):
         return val.val()
     return val
+
+
+def _dequote(str):
+    try:
+        return QUOTED_STR.findall(str)[0]
+    except IndexError:
+        raise AssertionError("Not a quoted string")
+
+
+def _uniquote(value):
+    """
+    Convert to unicode, and add quotes if initially a string
+    """
+    if isinstance(value, six.binary_type):
+        try:
+            value = value.decode('utf-8')
+        except UnicodeDecodeError:  # Not utf-8. Show the repr
+            value = six.text_type(_dequote(repr(value)))  # trim quotes
+
+    result = six.text_type(value)
+
+    if isinstance(value, six.text_type):
+        result = "'%s'" % result
+    return result
+
+
+def _repr(value):
+    value = repr(value)
+    if isinstance(value, six.binary_type):
+        value = value.decode('utf-8')
+    return value
 
 
 class Soupy(Node):

--- a/test_soupy.py
+++ b/test_soupy.py
@@ -638,36 +638,35 @@ class TestExpression(object):
 
     def test_operators(self):
 
-        assert (Q > 1).__eval__(2)
-        assert (Q >= 1).__eval__(1)
-        assert (Q <= 1).__eval__(1)
-        assert (Q < 1).__eval__(0)
-        assert (Q == 1).__eval__(1)
-        assert (Q != 1).__eval__(2)
+        assert (Q > 1).eval_(2)
+        assert (Q >= 1).eval_(1)
+        assert (Q <= 1).eval_(1)
+        assert (Q < 1).eval_(0)
+        assert (Q == 1).eval_(1)
+        assert (Q != 1).eval_(2)
 
-        assert not (Q > 1).__eval__(1)
-        assert not (Q >= 1).__eval__(0)
-        assert not (Q <= 1).__eval__(2)
-        assert not (Q < 1).__eval__(1)
-        assert not (Q == 1).__eval__(2)
-        assert not (Q != 1).__eval__(1)
+        assert not (Q > 1).eval_(1)
+        assert not (Q >= 1).eval_(0)
+        assert not (Q <= 1).eval_(2)
+        assert not (Q < 1).eval_(1)
+        assert not (Q == 1).eval_(2)
+        assert not (Q != 1).eval_(1)
 
-        assert (Q <= Q).__eval__(5)
+        assert (Q <= Q).eval_(5)
 
-        assert (Q + 5).__eval__(2) == 7
-        assert (Q - 1).__eval__(1) == 0
-        assert (Q * 2).__eval__(4) == 8
+        assert (Q + 5).eval_(2) == 7
+        assert (Q - 1).eval_(1) == 0
+        assert (Q * 2).eval_(4) == 8
 
         if not PY3:
-            assert operator.div(Q, 2).__eval__(3) == 1
+            assert operator.div(Q, 2).eval_(3) == 1
 
-        assert operator.truediv(Q, 2).__eval__(3) == 1.5
+        assert operator.truediv(Q, 2).eval_(3) == 1.5
 
-        assert (Q / 2).__eval__(4) == 2.0
-        assert (Q // 2).__eval__(4) == 2
-        assert (Q % 2).__eval__(3) == 1
-        assert (Q ** 2).__eval__(3) == 9
-
+        assert (Q / 2).eval_(4) == 2.0
+        assert (Q // 2).eval_(4) == 2
+        assert (Q % 2).eval_(3) == 1
+        assert (Q ** 2).eval_(3) == 9
 
     @pytest.mark.parametrize(('expr', 'rep'), [
         (Q, 'Q'),
@@ -684,7 +683,7 @@ class TestExpression(object):
         (Q + 3, "Q + 3"),
         ((Q + 3) * 5, "(Q + 3) * 5"),
         (5 * (Q + 3), "5 * (Q + 3)"),
-        (Q.map(Q+3), "Q.map(Q + 3)"),
+        (Q.map(Q + 3), "Q.map(Q + 3)"),
         (Q['∂ƒ'], "Q['∂ƒ']"),
         (Q('∂ƒ'), "Q('∂ƒ')"),
         (Q[b'\xc6'], "Q['\\xc6']"),
@@ -694,7 +693,7 @@ class TestExpression(object):
         (Q(b'"\'\xc6'), "Q('\"\\\'\\xc6')"),
         (Q['"\''], "Q['\"\'']"),
         (Q[b'"\'\xc6'], "Q['\"\\\'\\xc6']"),
-        ])
+    ])
     def test_str(self, expr, rep):
         assert text_type(expr) == rep
         # repr should be ascii on py2
@@ -704,7 +703,7 @@ class TestExpression(object):
     def test_nice_exception_message(self):
         val = str('test')
         with pytest.raises(AttributeError) as exc:
-            expr = Q.upper().foo.__eval__(val)
+            Q.upper().foo.eval_(val)
         assert exc.value.args[0] == (
             "'str' object has no attribute 'foo'"
             "\n\n\tEncountered when evaluating 'TEST'.foo"
@@ -712,7 +711,7 @@ class TestExpression(object):
 
     def test_nice_exception_message_with_key_error(self):
         with pytest.raises(KeyError) as exc:
-            expr = Q[str('a')].__eval__({})
+            Q[str('a')].eval_({})
         assert str(exc.value) == (
             "'a'\n\n\tEncountered when evaluating {}['a']"
         )
@@ -720,7 +719,7 @@ class TestExpression(object):
     def test_nice_long_exception_message(self):
         val = str('a' * 500)
         with pytest.raises(AttributeError) as exc:
-            expr = Q.upper().foo.__eval__(val)
+            Q.upper().foo.eval_(val)
         assert exc.value.args[0] == (
             "'str' object has no attribute 'foo'"
             "\n\n\tEncountered when evaluating <str instance>.foo"
@@ -728,7 +727,7 @@ class TestExpression(object):
 
     def test_debug_method(self):
         with pytest.raises(AttributeError):
-            Q.upper().foo.__eval__('test')
+            Q.upper().foo.eval_('test')
 
         dbg = Q.debug_()
         assert isinstance(dbg, QDebug)
@@ -773,6 +772,7 @@ def test_collection_api():
     Collection and NullCollection have identical interfaces
     """
     assert _public_api(Collection) == _public_api(NullCollection)
+
 
 def test_dequote():
 

--- a/test_soupy.py
+++ b/test_soupy.py
@@ -701,7 +701,6 @@ class TestExpression(object):
         if not PY3:
             assert repr(expr).encode('ascii')
 
-
     def test_nice_exception_message(self):
         val = str('test')
         with pytest.raises(AttributeError) as exc:
@@ -709,6 +708,13 @@ class TestExpression(object):
         assert exc.value.args[0] == (
             "'str' object has no attribute 'foo'"
             "\n\n\tEncountered when evaluating 'TEST'.foo"
+        )
+
+    def test_nice_exception_message_with_key_error(self):
+        with pytest.raises(KeyError) as exc:
+            expr = Q[str('a')].__eval__({})
+        assert str(exc.value) == (
+            "'a'\n\n\tEncountered when evaluating {}['a']"
         )
 
     def test_nice_long_exception_message(self):
@@ -726,16 +732,17 @@ class TestExpression(object):
 
         dbg = Q.debug_()
         assert isinstance(dbg, QDebug)
-        assert repr(dbg.full_expr) == 'Q.upper().foo'
-        assert repr(dbg.expr) == '.foo'
-        assert dbg.val == 'TEST'
+        assert repr(dbg.expr) == 'Q.upper().foo'
+        assert repr(dbg.inner_expr) == '.foo'
+        assert dbg.val == 'test'
+        assert dbg.inner_val == 'TEST'
 
     def test_debug_method_empty(self):
         del Q.__debug_info__
         dbg = Q.debug_()
 
         assert isinstance(dbg, QDebug)
-        assert dbg == (None, None, None)
+        assert dbg == (None, None, None, None)
 
 
 def _public_api(cls):

--- a/test_soupy.py
+++ b/test_soupy.py
@@ -9,7 +9,8 @@ from six import PY3, text_type
 
 from soupy import (Soupy, Node, NullValueError, NullNode,
                    Collection, NullCollection, Null, Q,
-                   Scalar, Wrapper, NavigableStringNode, either, QDebug)
+                   Scalar, Wrapper, NavigableStringNode, either, QDebug,
+                   _dequote)
 
 
 COLLECTION_PROPS = ('children',
@@ -765,3 +766,12 @@ def test_collection_api():
     Collection and NullCollection have identical interfaces
     """
     assert _public_api(Collection) == _public_api(NullCollection)
+
+def test_dequote():
+
+    assert _dequote("u'hi'") == 'hi'
+    assert _dequote("b'hi'") == 'hi'
+    assert _dequote("'hi'") == 'hi'
+    assert _dequote('u"hi \'there\'"') == "hi 'there'"
+    with pytest.raises(AssertionError):
+        _dequote('abc')


### PR DESCRIPTION
This adds helpful improvements to Q expressions
## Reprs

Before:

```
In [3]: Q.a.b.c.foo(5)
Out[3]: <soupy.Chain at 0x103edda50>
```

After:

```
In [2]: Q.a.b.c.foo(5)
Out[2]: Q.a.b.c.foo(5)
```
## Exception messages

```
In [3]: Q.upper().foo.__eval__('test')
...
AttributeError: 'str' object has no attribute 'foo'

    Encountered when evaluating 'TEST'.foo
```
## Debugging

The Q.debug_() method will return context information about the last exception raised in a Q expression

```
In [4]: Q.debug_()
Out[4]: QDebug(full_expr=Q.upper().foo, expr=.foo, val='TEST')
```
