### PR TITLE
Make wrappers hashable

### DIFF
--- a/soupy.py
+++ b/soupy.py
@@ -192,6 +192,13 @@ class BaseNull(Wrapper):
     def __hash__(self):
         return hash(type(self))
 
+    def __eq__(self, other):
+        return type(self)()
+
+    def __ne__(self, other):
+        return type(self)()
+
+
 
 @six.python_2_unicode_compatible
 class Some(Wrapper):
@@ -284,10 +291,13 @@ class Some(Wrapper):
         return self.map(Q.__setitem__(key, val))
 
     def __hash__(self):
-        try:
-            return hash(self._value)
-        except TypeError:
-            return id(self)
+        return hash(self._value)
+
+    def __eq__(self, other):
+        return self.map(lambda x: x == other)
+
+    def __ne__(self, other):
+        return self.map(lambda x: x != other)
 
 
 class Null(BaseNull):
@@ -298,12 +308,6 @@ class Null(BaseNull):
         return Null()
 
     def __call__(self, *args, **kwargs):
-        return Null()
-
-    def __eq__(self, other):
-        return Null()
-
-    def __ne__(self, other):
         return Null()
 
     def __gt__(self, other):
@@ -385,12 +389,6 @@ class Scalar(Some):
     def __call__(self, *args, **kwargs):
         return self.map(operator.methodcaller('__call__', *args, **kwargs))
 
-    def __eq__(self, other):
-        return self.map(lambda x: x == other)
-
-    def __ne__(self, other):
-        return self.map(lambda x: x != other)
-
     def __gt__(self, other):
         return self.map(lambda x: x > other)
 
@@ -450,10 +448,6 @@ class Scalar(Some):
         if isinstance(other, BaseNull):
             return other
         return self.map(Q / _unwrap(other))
-
-    def __hash__(self):
-        # must explicitly override for py3
-        return super(Scalar, self).__hash__()
 
 
 class Collection(Some):
@@ -994,6 +988,9 @@ class Node(NodeLike, Some):
     def prettify(self):
         return self.map(Q.prettify()).val()
 
+    def __len__(self):
+        return len(self._value)
+
     def __bool__(self):
         return True
 
@@ -1169,6 +1166,9 @@ class NullNode(NodeLike, BaseNull):
 
     def prettify(self):
         return "Null Node"
+
+    def __len__(self):
+        return 0
 
 
 def either(*funcs):

--- a/soupy.py
+++ b/soupy.py
@@ -189,6 +189,9 @@ class BaseNull(Wrapper):
 
     __repr__ = __str__
 
+    def __hash__(self):
+        return hash(type(self))
+
 
 @six.python_2_unicode_compatible
 class Some(Wrapper):
@@ -279,6 +282,12 @@ class Some(Wrapper):
 
     def __setitem__(self, key, val):
         return self.map(Q.__setitem__(key, val))
+
+    def __hash__(self):
+        try:
+            return hash(self._value)
+        except TypeError:
+            return id(self)
 
 
 class Null(BaseNull):

--- a/soupy.py
+++ b/soupy.py
@@ -345,6 +345,9 @@ class Null(BaseNull):
     def __truediv__(self, other):
         return Null()
 
+    def __hash__(self):
+        return super(Null, self).__hash__()
+
 
 class Scalar(Some):
 
@@ -447,6 +450,10 @@ class Scalar(Some):
         if isinstance(other, BaseNull):
             return other
         return self.map(Q / _unwrap(other))
+
+    def __hash__(self):
+        # must explicitly override for py3
+        return super(Scalar, self).__hash__()
 
 
 class Collection(Some):

--- a/test_soupy.py
+++ b/test_soupy.py
@@ -281,13 +281,6 @@ class TestScalar(object):
         assert hash(Scalar(2)) == hash(Scalar(2))
         assert hash(Some(2)) == hash(Some(2))
 
-    def test_hash_of_unhashable(self):
-        """
-        Hash falls back on id if content is unhashable
-        """
-        s = Scalar([])
-        assert hash(s) == id(s)
-
 
 class TestNull(object):
 
@@ -348,6 +341,9 @@ class TestNullNode(object):
 
     def test_str(self):
         assert str(NullNode()) == "NullNode()"
+
+    def test_len(self):
+        assert len(NullNode()) == 0
 
     def test_val_raises(self):
         with pytest.raises(NullValueError):

--- a/test_soupy.py
+++ b/test_soupy.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 from six import PY3, text_type
 
 from soupy import (Soupy, Node, NullValueError, NullNode,
-                   Collection, NullCollection, Null, Q,
+                   Collection, NullCollection, Null, Q, Some,
                    Scalar, Wrapper, NavigableStringNode, either, QDebug,
                    _dequote)
 
@@ -279,6 +279,7 @@ class TestScalar(object):
         wrappers are hashed by their content
         """
         assert hash(Scalar(2)) == hash(Scalar(2))
+        assert hash(Some(2)) == hash(Some(2))
 
     def test_hash_of_unhashable(self):
         """

--- a/test_soupy.py
+++ b/test_soupy.py
@@ -274,8 +274,26 @@ class TestScalar(object):
         s['b'] = 2
         assert s.val() == {'a': 1, 'b': 2}
 
+    def test_hash(self):
+        """
+        wrappers are hashed by their content
+        """
+        assert hash(Scalar(2)) == hash(Scalar(2))
+
+    def test_hash_of_unhashable(self):
+        """
+        Hash falls back on id if content is unhashable
+        """
+        s = Scalar([])
+        assert hash(s) == id(s)
+
 
 class TestNull(object):
+
+    def test_hash(self):
+        # hashing uses the type
+        assert hash(Null()) == hash(Null())
+        assert hash(Null()) != hash(NullNode())
 
     def test_call(self):
         assert isinstance(Null()(), Null)


### PR DESCRIPTION
Closes #10 

I need to double check what the rules are for the interaction between `==`, `hash`, and `is` before merging
