### PR TITLE
Version check for six

### DIFF
--- a/soupy.py
+++ b/soupy.py
@@ -2,15 +2,25 @@ from __future__ import print_function, division, unicode_literals
 
 from abc import ABCMeta, abstractproperty, abstractmethod
 from collections import namedtuple
+from distutils.version import LooseVersion
 from functools import wraps
 from itertools import takewhile, dropwhile
 import operator
 import re
 import sys
 
-from bs4 import BeautifulSoup, PageElement, NavigableString
-import six
-from six.moves import map
+try:
+    from bs4 import BeautifulSoup, PageElement, NavigableString
+except ImportError:
+    raise ImportError("Soupy requires beautifulsoup4")  # pragma: no cover
+
+try:
+    import six
+    from six.moves import map
+    assert LooseVersion(six.__version__) >= LooseVersion('1.9')
+except(ImportError, AssertionError):
+    raise ImportError(
+        "Soupy requires six version 1.9 or later")  # pragma: no cover
 
 __version__ = '0.4.dev'
 

--- a/soupy.py
+++ b/soupy.py
@@ -11,16 +11,15 @@ import sys
 
 try:
     from bs4 import BeautifulSoup, PageElement, NavigableString
-except ImportError:
-    raise ImportError("Soupy requires beautifulsoup4")  # pragma: no cover
+except ImportError:  # pragma: no cover
+    raise ImportError("Soupy requires beautifulsoup4")
 
 try:
     import six
     from six.moves import map
     assert LooseVersion(six.__version__) >= LooseVersion('1.9')
-except(ImportError, AssertionError):
-    raise ImportError(
-        "Soupy requires six version 1.9 or later")  # pragma: no cover
+except(ImportError, AssertionError):   # pragma: no cover
+    raise ImportError("Soupy requires six version 1.9 or later")
 
 __version__ = '0.4.dev'
 


### PR DESCRIPTION
Provides a better error message if an old version of six is installed. Closes #13 

We could also define a requirements file and/or install dependency to update six automatically if needed, but I don't like the idea of implicit updates.
