### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Soupy
 
-[![Latest Version](https://pypip.in/version/soupy/badge.svg)](https://pypi.python.org/pypi/soupy/)
-[![License](https://pypip.in/license/soupy/badge.svg)](https://pypi.python.org/pypi/soupy/)
+[![Latest Version](https://img.shields.io/pypi/v/soupy.svg)](https://pypi.python.org/pypi/soupy/)
+[![License](https://img.shields.io/pypi/l/soupy.svg)](https://pypi.python.org/pypi/soupy/)
 [![Build Status](https://travis-ci.org/ChrisBeaumont/soupy.svg?branch=master)](https://travis-ci.org/ChrisBeaumont/soupy) [![Coverage Status](https://coveralls.io/repos/ChrisBeaumont/soupy/badge.svg)](https://coveralls.io/r/ChrisBeaumont/soupy)
 
 Soupy is a wrapper around BeautifulSoup that makes it easier


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20soupy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `soupy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.